### PR TITLE
Fixed bug where rack array parameters weren't encoded

### DIFF
--- a/lib/url-template.js
+++ b/lib/url-template.js
@@ -50,8 +50,9 @@
       return [key + '[]='];
     }
 
+    const self = this;
     const encoded = arr.map(function(val, idx) {
-      return key + '[]=' + val;
+      return key + '[]=' + self.encodeValue(operator, val);
     });
 
     return encoded.join('&');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reverbdotcom/url-template",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "decription": "A URI template implementation (RFC 6570 compliant)",
   "author": "Bram Stein <b.l.stein@gmail.com> (http://www.bramstein.com)",
   "keywords": [

--- a/test/url-template-test.js
+++ b/test/url-template-test.js
@@ -166,6 +166,7 @@ describe('uri-template', function () {
           'hello': 'Hello World!',
           'path': '/foo/bar',
           'list': ['red', 'green', 'blue'],
+          'encodedlist': ['d&d', '110%', '#1'],
           'keys': {
             'semi': ';',
             'dot': '.',
@@ -200,6 +201,13 @@ describe('uri-template', function () {
       assert('{undefinedlistitem}', '1,2');
       assert('{undefinedlistitem*}', '1,2');
       assert('{?undefinedlistitem*}', '?undefinedlistitem[]=1&undefinedlistitem[]=2');
+    });
+
+    it('variable encoded list', function () {
+      assert('{?encodedlist}', '?encodedlist[]=d%26d&encodedlist[]=110%25&encodedlist[]=%231');
+      assert('{&encodedlist}', '&encodedlist[]=d%26d&encodedlist[]=110%25&encodedlist[]=%231');
+      assert('{?encodedlist*}', '?encodedlist[]=d%26d&encodedlist[]=110%25&encodedlist[]=%231');
+      assert('{&encodedlist*}', '&encodedlist[]=d%26d&encodedlist[]=110%25&encodedlist[]=%231');
     });
 
     it('variable undefined object item', function () {


### PR DESCRIPTION
This fix will help us out on LP, where we're having issues with unencoded URL params.