### PR TITLE
Add typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,15 @@
+// Type definitions for @reverbdotcom/url-template
+// Project: https://github.com/reverbdotcom/url-template
+
+export namespace urltemplate;
+
+interface BaseContext {
+  [key: string]: any;
+}
+
+export interface ParsedTemplate<T> {
+  expand: (context: T) => string;
+}
+
+export function parse<T extends BaseContext = BaseContext>(template: string): ParsedTemplate<T>;
+

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "url": "git://github.com/bramstein/url-template.git"
   },
   "main": "./lib/url-template.js",
+  "types": "./index.d.ts",
   "directories": {
     "lib": "./lib"
   },


### PR DESCRIPTION
This will let us define type-safe URL templates, e.g.

```typescript
interface Id { id: string | number; }
const ALBUM_SHOW = template.parse<Id>('/albums/{id}');

ALBUM_SHOW.expand({ slug: 'dark-side-of-the-moon' });    // Error!
ALBUM_SHOW.expand({ id: '12345' });    // OK
```