### PR TITLE
Remove invalid namespace syntax

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,6 @@
 // Type definitions for @reverbdotcom/url-template
 // Project: https://github.com/reverbdotcom/url-template
 
-export namespace urltemplate;
-
 interface BaseContext {
   [key: string]: any;
 }


### PR DESCRIPTION
I think this was messed up copypasta, we shouldn't need a namespace at all.